### PR TITLE
Rewrote experiment timeline & added No Response threshold

### DIFF
--- a/Task/feedback.js
+++ b/Task/feedback.js
@@ -55,7 +55,7 @@ function drawPieFeedback(scores, block_num, trial_num){
 	return;
 }
 
-function drawCumulativePieFeedback(trial_num){
+function drawCumulativePieFeedback(){
 	drawPieChart(old_angle, old_angle, false);
 	return;
 }

--- a/Task/stim_config.js
+++ b/Task/stim_config.js
@@ -82,6 +82,9 @@ const t_intertrialbreak = 2000;
 /* Inter-block interval */
 const t_interblockbreak = 10000;
 
+/* Duration of NoResponse Reset Instruction Display */
+const t_noresp_reset = 5000;
+
 /***********************************/
 /* Feedback  */
 /***********************************/


### PR DESCRIPTION
Rewrote experiment timeline definition to include looped timelines and conditional timelines.

Now the task supports the no response threshold feature. If in a block, no response threshold (number of trials in which the response was not registered) is reached, the subject is notified and the block and block's scores are reset. 